### PR TITLE
Display user list from API in React app

### DIFF
--- a/frontend/myapp/src/App.js
+++ b/frontend/myapp/src/App.js
@@ -1,23 +1,29 @@
-import logo from './logo.svg';
+import { useEffect, useState } from 'react';
 import './App.css';
 
+/**
+ * 사용자 목록을 출력하는 간단한 컴포넌트
+ */
 function App() {
+  const [users, setUsers] = useState([]);
+
+  useEffect(() => {
+    fetch('http://192.168.0.121:8080/api/users')
+      .then((res) => res.json())
+      .then((data) => setUsers(data))
+      .catch((err) => console.error('사용자 정보 조회 실패', err));
+  }, []);
+
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <h1>사용자 목록</h1>
+      <ul>
+        {users.map((user) => (
+          <li key={user.userId} data-testid="user-item">
+            {user.name} ({user.loginId})
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/frontend/myapp/src/App.test.js
+++ b/frontend/myapp/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('사용자 목록 제목이 화면에 표시된다', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/사용자 목록/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- fetch users from `http://192.168.0.121:8080/api/users`
- display them in the React frontend
- adjust unit test to expect the heading

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569f3b5880832488ef57c00f51b73b